### PR TITLE
Allow user-defined types

### DIFF
--- a/lib/JSON/Schema/Fit.pm
+++ b/lib/JSON/Schema/Fit.pm
@@ -107,15 +107,31 @@ Default: 1
 
 sub hash_keys { return _attr('hash_keys', @_); }
 
+=attr types
+
+   # fruits can be oranges or apples, only! Oranges by default.
+   $jsf->types( { fruit => sub { 
+        my ($self, $struc, $schema, $jpath) = @_;
+        return "orange" unless $struc =~ /^apple$/; i
+        return $struc;
+   }});
+
+Define user-specific types, like enumerators.
+
+=cut
+
+sub types { return _attr('types', @_); }
+
 # Store valid options as well as default values
-my %valid_option = ( map { ($_ => 1) } qw!booleans numbers round_numbers strings hash_keys! );
+my %valid_option = ( map { ($_ => 1) } qw!booleans numbers round_numbers strings hash_keys!, types => {} );
 
 sub new { 
     my ($class, %opts) = @_;
     my $self = bless {}, $class;
+
     for my $k (keys %opts) {
         next unless exists $valid_option{$k};
-        $self->_attr($k, $opts{$k});
+        _attr($k, $self, $opts{$k});
     }
     return $self
 }
@@ -152,6 +168,7 @@ sub _adjuster_by_type {
     return if !$type;
     my $method = "_get_adjusted_$type";
     return $method if $self->can($method);
+    return $self->{types}{$type} if exists $self->{types}{$type} and ref($self->{types}{$type}) eq "CODE";
     return;
 }
 

--- a/t/get_adjusted.t
+++ b/t/get_adjusted.t
@@ -29,9 +29,19 @@ my @tests = (
         {aa=>0.1, bb=>0.1},
         {aa=>0}
     ],
+    [ { type => 'fruit' }, "apple", "apple" ],
+    [ { type => 'fruit' }, "kiwi", "orange" ],
 );
 
-my $jsa = JSON::Schema::Fit->new();
+my $types = {
+    fruit => sub { 
+        my (undef, $val) = @_;
+        return "orange" unless $val =~ /^apple$/;
+        return $val;
+    }
+};
+
+my $jsa = JSON::Schema::Fit->new( types => $types);
 for my $test ( @tests ) {
     my ($schema, $param, $expected, $name) = @$test;
     cmp_deeply( $jsa->get_adjusted($param, $schema), $expected, $name || to_json($schema) );


### PR DESCRIPTION
Hello again!

I found a mistake I added in the last PR, calling _attr as a method. Probably I should rewrite it as a method and adapt the code. If you wish I can do that. But for now, fixed the mistake. Sorry!

I was adding a new functionality on my module (btw, its Arango::DB) and I needed a flag whose valid values are 0, 1 or 2. So, I added a small functionality to allow user-defined types (well, leaf types).

Finally, I am giving priority to builtin adjusting methods. But this approach can be used to allow user-defined methods, just changing the order by which adjust methods are searched. Just not sure we should allow if for array and dictionary/hash.

Thanks! 